### PR TITLE
Remove leading slash from smwQueryUrl

### DIFF
--- a/src/Render/Themes/Plain/PlainTokenRenderer.php
+++ b/src/Render/Themes/Plain/PlainTokenRenderer.php
@@ -191,7 +191,7 @@ class PlainTokenRenderer implements TokenRenderer {
 
 		global $wgScriptPath, $wgServer;
 		if ( $wgScriptPath !== "" ) {
-			$smwQueryUrl = "/" . $wgScriptPath . '/index.php/Special:FlexForm';
+			$smwQueryUrl = $wgScriptPath . '/index.php/Special:FlexForm';
 		} else {
 			$smwQueryUrl = '/index.php/Special:FlexForm';
 		}


### PR DESCRIPTION
When 'wgScriptPath' is set, this already includes a leading slash. For instance, the default value is '/wiki'. With the old logic in place, this would result in calling '//index.php/Special:FlexForm' - which fails to load any result. Removing the leading slash fixes it. 